### PR TITLE
Simplified database config by using .env file

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,13 @@
 # Webserver
 ENV_PHP_VERSION=8.2
 
+# Database
+ENV_MYSQL_ROOT_PASSWORD=very_difficult_password_1
+ENV_MYSQL_DATABASE=omekas
+ENV_MYSQL_USER=omekas
+ENV_MYSQL_PASSWORD=difficult_omek4s_password
+ENV_MYSQL_HOST=db
+
 # Omeka S
 ENV_OMEKAS_VERSION=4.0.4
 ENV_MODULE_AdvancedSearch_VERSION=3.4.21

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 secret_*
-omeka-s/config/database.ini
 omeka-s/sideload/
 externals/*
 !externals/README.md

--- a/README-03-PhpStorm-Xdebug.md
+++ b/README-03-PhpStorm-Xdebug.md
@@ -79,7 +79,7 @@ apt-get update && apt-get install telnet -y
 ```
 1. Use telnet to verify connectivity
 ```
-telnet host.docker.internal 9003
+telnet dockerhost.local 9003
 ```
 
 ## Install Xdebug plugin in browser

--- a/README.md
+++ b/README.md
@@ -33,29 +33,10 @@ git clone https://github.com/MaastrichtU-Library/omekas-theme-um.git
 **IMPORTANT:** The externals repositories are not automatically updated locally, so make sure to `git pull` changes 
 from those repositories periodically.
 
+## Set configuration options in .env file
+1. Open the `.env` file in a text editor.
+2. Change values accordingly. E.g. change module versions. hostnames, etc.
 
-**Set database connection settings**
-
-1. Edit the `docker-compose.yml` file and enter values for:
-    ```
-    MYSQL_ROOT_PASSWORD:
-    MYSQL_DATABASE: 
-    MYSQL_USER:
-    MYSQL_PASSWORD:
-    ```
-
-1. Copy the example database config for Omeka S
-    ```
-    cp omeka-s/config/example_database.ini omeka-s/config/database.ini
-    ```
-
-1. Edit the `database.ini` file with a text editor and enter the same values for:
-    ```
-    user     = 
-    password = 
-    dbname   = 
-    host     = 
-    ```
 
 ## Build instructions
 Build the Omeka S infra with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,10 @@ services:
     container_name: omekas
     environment: 
       VIRTUAL_HOST: omeka.local
+      MYSQL_DATABASE: ${ENV_MYSQL_DATABASE}
+      MYSQL_USER: ${ENV_MYSQL_USER}
+      MYSQL_PASSWORD: ${ENV_MYSQL_PASSWORD}
+      MYSQL_HOST: ${ENV_MYSQL_HOST}
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - omeka:/var/www/html/volume
@@ -59,10 +63,10 @@ services:
     container_name: omekas_db
     command: --max_allowed_packet=2147483648
     environment:
-      MYSQL_ROOT_PASSWORD: very_difficult_password_1 
-      MYSQL_DATABASE: omekas
-      MYSQL_USER: omekas
-      MYSQL_PASSWORD: difficult_omek4s_password
+      MYSQL_ROOT_PASSWORD: ${ENV_MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${ENV_MYSQL_DATABASE}
+      MYSQL_USER: ${ENV_MYSQL_USER}
+      MYSQL_PASSWORD: ${ENV_MYSQL_PASSWORD}
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - db:/var/lib/mysql

--- a/omeka-s/config/example_database.ini
+++ b/omeka-s/config/example_database.ini
@@ -1,8 +1,0 @@
-user     = 
-password = 
-dbname   = 
-host     = 
-;port     = 
-;unix_socket = 
-;log_path = 
-

--- a/omeka-s/docker-entrypoint.sh
+++ b/omeka-s/docker-entrypoint.sh
@@ -4,6 +4,16 @@
 echo "$(ip route|awk '/default/ { print $3 }') dockerhost.local" >> /etc/hosts
 
 ### Omeka configurations that need to happen during runtime ###
+
+# Generate database configuration file
+echo "Creating database.ini in /var/www/html/config/ ..."
+rm -f /var/www/html/config/database.ini
+echo "user     = \"$MYSQL_USER\"" > /var/www/html/config/database.ini
+echo "password = \"$MYSQL_PASSWORD\"" >> /var/www/html/config/database.ini
+echo "dbname   = \"$MYSQL_DATABASE\"" >> /var/www/html/config/database.ini
+echo "host     = \"$MYSQL_HOST\"" >> /var/www/html/config/database.ini
+echo "Done creating database.ini !"
+
 # Note: Docker volume-binds are not available during build stage.
 if [[ ! -d /var/www/html/files/temp ]]
 then


### PR DESCRIPTION
Previously, there were manual steps described in the README on creating and setting values in the `database.ini` file. The fix in this PR fully automates the creation of the `database.ini` by using environment variables shared between the `omekas` and `db` containers.

Fixes #10 